### PR TITLE
Add Page class for use with NavigatorView

### DIFF
--- a/miru/abc/item_handler.py
+++ b/miru/abc/item_handler.py
@@ -329,7 +329,7 @@ class ItemHandler(Sequence, abc.ABC, t.Generic[BuilderT]):  # type: ignore[type-
 
     def _create_task(self, coro: t.Awaitable[t.Any], *, name: t.Optional[str] = None) -> asyncio.Task[t.Any]:
         """
-        Run tasks inside the itemhandler internally while keeping a reference to the provided task.
+        Run tasks inside the item handler internally while keeping a reference to the provided task.
         """
         task = asyncio.create_task(coro, name=name)  # type: ignore
         self._running_tasks.append(task)
@@ -337,7 +337,7 @@ class ItemHandler(Sequence, abc.ABC, t.Generic[BuilderT]):  # type: ignore[type-
         return task
 
     async def wait(self, timeout: t.Optional[float] = None) -> None:
-        """Wait until the item handler has stopped receiveing interactions.
+        """Wait until the item handler has stopped receiving interactions.
 
         Parameters
         ----------

--- a/miru/context/base.py
+++ b/miru/context/base.py
@@ -495,7 +495,7 @@ class Context(abc.ABC, t.Generic[InteractionT]):
         RuntimeError
             The interaction was already responded to.
         ValueError
-            response_type was not a deffered response type.
+            response_type was not a deferred response type.
         """
         response_type = args[0] if args else hikari.ResponseType.DEFERRED_MESSAGE_UPDATE
 

--- a/miru/exceptions.py
+++ b/miru/exceptions.py
@@ -6,7 +6,7 @@ class MiruException(Exception):
 
 
 class BootstrapFailureError(MiruException):
-    """Raised when the requested operation requires calling miru.install() beforehand, but was ommitted."""
+    """Raised when the requested operation requires calling miru.install() beforehand, but was omitted."""
 
 
 class RowFullError(MiruException):

--- a/miru/ext/nav/__init__.py
+++ b/miru/ext/nav/__init__.py
@@ -10,6 +10,7 @@ from .items import (
     NavTextSelect,
     NavUserSelect,
     NextButton,
+    Page,
     PrevButton,
     StopButton,
 )
@@ -30,6 +31,7 @@ __all__ = (
     "LastButton",
     "IndicatorButton",
     "StopButton",
+    "Page",
     "NavigatorView",
     "Paginator",
 )

--- a/miru/ext/nav/__init__.py
+++ b/miru/ext/nav/__init__.py
@@ -10,11 +10,10 @@ from .items import (
     NavTextSelect,
     NavUserSelect,
     NextButton,
-    Page,
     PrevButton,
     StopButton,
 )
-from .navigator import NavigatorView
+from .navigator import NavigatorView, Page
 from .utils import *
 
 __all__ = (

--- a/miru/ext/nav/items.py
+++ b/miru/ext/nav/items.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import abc
-import attr
 import typing as t
 
 import hikari
@@ -276,49 +275,6 @@ class StopButton(NavButton):
         elif self.view.message:
             await self.view.message.edit(components=self.view)
         self.view.stop()
-
-
-@attr.define(slots=True)
-class Page:
-    """Allows for the building of more complex pages for use with NavigatorView."""
-    
-    content: hikari.UndefinedOr[t.Any] = hikari.UNDEFINED
-    """The content of the message. Anything passed here will be cast to str."""
-    attachment: hikari.UndefinedOr[hikari.Resourceish] = hikari.UNDEFINED
-    """An attachment to add to this page."""
-    attachments: hikari.UndefinedOr[t.Sequence[hikari.Resourceish]] = hikari.UNDEFINED
-    """A sequence of attachments to add to this page."""
-    embed: hikari.UndefinedOr[hikari.Embed] = hikari.UNDEFINED
-    """An embed to add to this page."""
-    embeds: hikari.UndefinedOr[t.Sequence[hikari.Embed]] = hikari.UNDEFINED
-    """A sequence of embeds to add to this page."""
-    mentions_everyone: hikari.UndefinedOr[bool] = hikari.UNDEFINED
-    """If True, mentioning @everyone will be allowed in this page's message."""
-    user_mentions: hikari.UndefinedOr[
-        t.Union[hikari.SnowflakeishSequence[hikari.PartialUser], bool]
-    ] = hikari.UNDEFINED
-    """The set of allowed user mentions in this page's message. Set to True to allow all."""
-    role_mentions: hikari.UndefinedOr[
-        t.Union[hikari.SnowflakeishSequence[hikari.PartialRole], bool]
-    ] = hikari.UNDEFINED
-    """The set of allowed role mentions in this page's message. Set to True to allow all."""
-
-    def _build_payload(self) -> dict[str, t.Any]:
-        d: dict[str, t.Any] = dict(
-            content=self.content or None,
-            attachments=self.attachments or None,
-            embeds=self.embeds or None,
-            mentions_everyone=self.mentions_everyone or False,
-            user_mentions=self.user_mentions or False,
-            role_mentions=self.role_mentions or False,
-        )
-        if not d["attachments"] and self.attachment:
-            d["attachments"] = [self.attachment]
-
-        if not d["embeds"] and self.embed:
-            d["embeds"] = [self.embed]
-        
-        return d
 
 
 # MIT License

--- a/miru/ext/nav/items.py
+++ b/miru/ext/nav/items.py
@@ -293,6 +293,23 @@ class Page:
         t.Union[hikari.SnowflakeishSequence[hikari.PartialRole], bool]
     ] = hikari.UNDEFINED
 
+    def _build_payload(self) -> dict[str, t.Any]:
+        d: dict[str, t.Any] = dict(
+            content=self.content or None,
+            attachments=self.attachments or None,
+            embeds=self.embeds or None,
+            mentions_everyone=self.mentions_everyone or False,
+            user_mentions=self.user_mentions or False,
+            role_mentions=self.role_mentions or False,
+        )
+        if not d["attachments"] and self.attachment:
+            d["attachments"] = [self.attachment]
+
+        if not d["embeds"] and self.embed:
+            d["embeds"] = [self.embed]
+        
+        return d
+
 
 # MIT License
 #

--- a/miru/ext/nav/items.py
+++ b/miru/ext/nav/items.py
@@ -278,20 +278,30 @@ class StopButton(NavButton):
         self.view.stop()
 
 
-@attr.define()
+@attr.define(slots=True)
 class Page:
+    """Allows for the building of more complex pages for use with NavigatorView."""
+    
     content: hikari.UndefinedOr[t.Any] = hikari.UNDEFINED
+    """The content of the message. Anything passed here will be cast to str."""
     attachment: hikari.UndefinedOr[hikari.Resourceish] = hikari.UNDEFINED
+    """An attachment to add to this page."""
     attachments: hikari.UndefinedOr[t.Sequence[hikari.Resourceish]] = hikari.UNDEFINED
+    """A sequence of attachments to add to this page."""
     embed: hikari.UndefinedOr[hikari.Embed] = hikari.UNDEFINED
+    """An embed to add to this page."""
     embeds: hikari.UndefinedOr[t.Sequence[hikari.Embed]] = hikari.UNDEFINED
+    """A sequence of embeds to add to this page."""
     mentions_everyone: hikari.UndefinedOr[bool] = hikari.UNDEFINED
+    """If True, mentioning @everyone will be allowed in this page's message."""
     user_mentions: hikari.UndefinedOr[
         t.Union[hikari.SnowflakeishSequence[hikari.PartialUser], bool]
     ] = hikari.UNDEFINED
+    """The set of allowed user mentions in this page's message. Set to True to allow all."""
     role_mentions: hikari.UndefinedOr[
         t.Union[hikari.SnowflakeishSequence[hikari.PartialRole], bool]
     ] = hikari.UNDEFINED
+    """The set of allowed role mentions in this page's message. Set to True to allow all."""
 
     def _build_payload(self) -> dict[str, t.Any]:
         d: dict[str, t.Any] = dict(

--- a/miru/ext/nav/items.py
+++ b/miru/ext/nav/items.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import attr
 import typing as t
 
 import hikari
@@ -275,6 +276,22 @@ class StopButton(NavButton):
         elif self.view.message:
             await self.view.message.edit(components=self.view)
         self.view.stop()
+
+
+@attr.define()
+class Page:
+    content: hikari.UndefinedOr[t.Any] = hikari.UNDEFINED
+    attachment: hikari.UndefinedOr[hikari.Resourceish] = hikari.UNDEFINED
+    attachments: hikari.UndefinedOr[t.Sequence[hikari.Resourceish]] = hikari.UNDEFINED
+    embed: hikari.UndefinedOr[hikari.Embed] = hikari.UNDEFINED
+    embeds: hikari.UndefinedOr[t.Sequence[hikari.Embed]] = hikari.UNDEFINED
+    mentions_everyone: hikari.UndefinedOr[bool] = hikari.UNDEFINED
+    user_mentions: hikari.UndefinedOr[
+        t.Union[hikari.SnowflakeishSequence[hikari.PartialUser], bool]
+    ] = hikari.UNDEFINED
+    role_mentions: hikari.UndefinedOr[
+        t.Union[hikari.SnowflakeishSequence[hikari.PartialRole], bool]
+    ] = hikari.UNDEFINED
 
 
 # MIT License

--- a/miru/ext/nav/navigator.py
+++ b/miru/ext/nav/navigator.py
@@ -170,7 +170,10 @@ class NavigatorView(View):
             embeds = [page] if isinstance(page, hikari.Embed) else []
 
         if not content and not embeds:
-            raise TypeError(f"Expected type 'str' or 'hikari.Embed' to send as page, not '{page.__class__.__name__}'.")
+            raise TypeError(
+                "Expected type 'str', 'hikari.Embed', 'Sequence[hikari.Embed]' or 'ext.nav.Page' "
+                f"to send as page, not '{page.__class__.__name__}'."
+            )
 
         d = dict(
             content=content,

--- a/miru/ext/nav/navigator.py
+++ b/miru/ext/nav/navigator.py
@@ -156,28 +156,8 @@ class NavigatorView(View):
         """Get the page content that is to be sent."""
 
         if isinstance(page, Page):
-            d: dict[str, t.Any] = dict(
-                content=page.content or None,
-                mentions_everyone=page.mentions_everyone or False,
-                user_mentions=page.user_mentions or False,
-                role_mentions=page.role_mentions or False,
-                components=self,
-            )
-            if page.attachment and not page.attachments:
-                d["attachment"] = page.attachment
-            elif page.attachments and not page.attachment:
-                d["attachments"] = page.attachments
-            elif not page.attachment and not page.attachments:
-                d["attachment"] = None
-
-            if page.embed and not page.embeds:
-                d["embed"] = page.embed
-            elif page.embeds and not page.embed:
-                d["embeds"] = page.embeds
-            elif not page.embed and not page.embeds:
-                d["embed"] = None
-
-
+            d = page._build_payload()
+            d["components"] = self
             if self.ephemeral:
                 d["flags"] = hikari.MessageFlag.EPHEMERAL
             return d

--- a/miru/ext/nav/navigator.py
+++ b/miru/ext/nav/navigator.py
@@ -22,7 +22,7 @@ class NavigatorView(View):
 
     Parameters
     ----------
-    pages : List[Union[str, hikari.Embed, Sequence[hikari.Embed] | Page]]
+    pages : List[Union[str, hikari.Embed, Sequence[hikari.Embed], Page]]
         A list of strings or embeds that this navigator should paginate.
     buttons : Optional[List[NavButton[NavigatorViewT]]], optional
         A list of navigation buttons to override the default ones with, by default None
@@ -218,7 +218,7 @@ class NavigatorView(View):
     async def swap_pages(
         self,
         context: Context[t.Any],
-        new_pages: t.Sequence[t.Union[str, hikari.Embed, t.Sequence[hikari.Embed] | Page]],
+        new_pages: t.Sequence[t.Union[str, hikari.Embed, t.Sequence[hikari.Embed], Page]],
         start_at: int = 0,
     ) -> None:
         """Swap out the pages of the navigator to the newly provided pages.

--- a/miru/ext/nav/navigator.py
+++ b/miru/ext/nav/navigator.py
@@ -198,7 +198,7 @@ class NavigatorView(View):
         context : Context
             The context object that should be used to send this page
         page_index : Optional[int], optional
-            The index of the page to send, if not specifed, sends the current page, by default None
+            The index of the page to send, if not specified, sends the current page, by default None
         """
         if page_index is not None:
             self.current_page = page_index

--- a/miru/ext/nav/navigator.py
+++ b/miru/ext/nav/navigator.py
@@ -189,7 +189,7 @@ class NavigatorView(View):
             d["flags"] = hikari.MessageFlag.EPHEMERAL
 
         return d
-        
+
     @property
     def is_persistent(self) -> bool:
         return super().is_persistent and not self.ephemeral
@@ -326,7 +326,7 @@ class NavigatorView(View):
 @attr.define(slots=True)
 class Page:
     """Allows for the building of more complex pages for use with NavigatorView."""
-    
+
     content: hikari.UndefinedOr[t.Any] = hikari.UNDEFINED
     """The content of the message. Anything passed here will be cast to str."""
     attachment: hikari.UndefinedOr[hikari.Resourceish] = hikari.UNDEFINED
@@ -339,13 +339,9 @@ class Page:
     """A sequence of embeds to add to this page."""
     mentions_everyone: hikari.UndefinedOr[bool] = hikari.UNDEFINED
     """If True, mentioning @everyone will be allowed in this page's message."""
-    user_mentions: hikari.UndefinedOr[
-        t.Union[hikari.SnowflakeishSequence[hikari.PartialUser], bool]
-    ] = hikari.UNDEFINED
+    user_mentions: hikari.UndefinedOr[t.Union[hikari.SnowflakeishSequence[hikari.PartialUser], bool]] = hikari.UNDEFINED
     """The set of allowed user mentions in this page's message. Set to True to allow all."""
-    role_mentions: hikari.UndefinedOr[
-        t.Union[hikari.SnowflakeishSequence[hikari.PartialRole], bool]
-    ] = hikari.UNDEFINED
+    role_mentions: hikari.UndefinedOr[t.Union[hikari.SnowflakeishSequence[hikari.PartialRole], bool]] = hikari.UNDEFINED
     """The set of allowed role mentions in this page's message. Set to True to allow all."""
 
     def _build_payload(self) -> dict[str, t.Any]:
@@ -362,9 +358,9 @@ class Page:
 
         if not d["embeds"] and self.embed:
             d["embeds"] = [self.embed]
-        
+
         return d
-    
+
 
 # MIT License
 #

--- a/miru/ext/nav/navigator.py
+++ b/miru/ext/nav/navigator.py
@@ -4,17 +4,18 @@ import datetime
 import logging
 import typing as t
 
+import attr
 import hikari
 
 from miru.abc import Item
 from miru.context import Context
 from miru.view import View
 
-from .items import FirstButton, IndicatorButton, LastButton, NavButton, NavItem, NextButton, Page, PrevButton
+from .items import FirstButton, IndicatorButton, LastButton, NavButton, NavItem, NextButton, PrevButton
 
 logger = logging.getLogger(__name__)
 
-__all__ = ("NavigatorView",)
+__all__ = ("NavigatorView", "Page")
 
 
 class NavigatorView(View):
@@ -318,6 +319,49 @@ class NavigatorView(View):
 
         await self.start(message, start_at=start_at)
 
+
+@attr.define(slots=True)
+class Page:
+    """Allows for the building of more complex pages for use with NavigatorView."""
+    
+    content: hikari.UndefinedOr[t.Any] = hikari.UNDEFINED
+    """The content of the message. Anything passed here will be cast to str."""
+    attachment: hikari.UndefinedOr[hikari.Resourceish] = hikari.UNDEFINED
+    """An attachment to add to this page."""
+    attachments: hikari.UndefinedOr[t.Sequence[hikari.Resourceish]] = hikari.UNDEFINED
+    """A sequence of attachments to add to this page."""
+    embed: hikari.UndefinedOr[hikari.Embed] = hikari.UNDEFINED
+    """An embed to add to this page."""
+    embeds: hikari.UndefinedOr[t.Sequence[hikari.Embed]] = hikari.UNDEFINED
+    """A sequence of embeds to add to this page."""
+    mentions_everyone: hikari.UndefinedOr[bool] = hikari.UNDEFINED
+    """If True, mentioning @everyone will be allowed in this page's message."""
+    user_mentions: hikari.UndefinedOr[
+        t.Union[hikari.SnowflakeishSequence[hikari.PartialUser], bool]
+    ] = hikari.UNDEFINED
+    """The set of allowed user mentions in this page's message. Set to True to allow all."""
+    role_mentions: hikari.UndefinedOr[
+        t.Union[hikari.SnowflakeishSequence[hikari.PartialRole], bool]
+    ] = hikari.UNDEFINED
+    """The set of allowed role mentions in this page's message. Set to True to allow all."""
+
+    def _build_payload(self) -> dict[str, t.Any]:
+        d: dict[str, t.Any] = dict(
+            content=self.content or None,
+            attachments=self.attachments or None,
+            embeds=self.embeds or None,
+            mentions_everyone=self.mentions_everyone or False,
+            user_mentions=self.user_mentions or False,
+            role_mentions=self.role_mentions or False,
+        )
+        if not d["attachments"] and self.attachment:
+            d["attachments"] = [self.attachment]
+
+        if not d["embeds"] and self.embed:
+            d["embeds"] = [self.embed]
+        
+        return d
+    
 
 # MIT License
 #

--- a/miru/ext/nav/navigator.py
+++ b/miru/ext/nav/navigator.py
@@ -22,7 +22,7 @@ class NavigatorView(View):
 
     Parameters
     ----------
-    pages : List[Union[str, hikari.Embed, Sequence[hikari.Embed]]]
+    pages : List[Union[str, hikari.Embed, Sequence[hikari.Embed] | Page]]
         A list of strings or embeds that this navigator should paginate.
     buttons : Optional[List[NavButton[NavigatorViewT]]], optional
         A list of navigation buttons to override the default ones with, by default None
@@ -218,7 +218,7 @@ class NavigatorView(View):
     async def swap_pages(
         self,
         context: Context[t.Any],
-        new_pages: t.Sequence[t.Union[str, hikari.Embed, t.Sequence[hikari.Embed]]],
+        new_pages: t.Sequence[t.Union[str, hikari.Embed, t.Sequence[hikari.Embed] | Page]],
         start_at: int = 0,
     ) -> None:
         """Swap out the pages of the navigator to the newly provided pages.
@@ -228,7 +228,7 @@ class NavigatorView(View):
         ----------
         context : Context
             The context object that should be used to send the updated pages
-        new_pages : Sequence[Union[str, Embed, Sequence[Embed]]]
+        new_pages : Sequence[Union[str, Embed, Sequence[Embed] | Page]]
             The new pages to swap to
         start_at : int, optional
             The page to start at, by default 0

--- a/miru/ext/nav/utils/paginator.py
+++ b/miru/ext/nav/utils/paginator.py
@@ -55,7 +55,7 @@ class Paginator:
         Parameters
         ----------
         line : str
-            The string to add to the paginator. If it contains the line seperator, the text will be split into multiple lines.
+            The string to add to the paginator. If it contains the line separator, the text will be split into multiple lines.
         Raises
         ------
         ValueError

--- a/miru/modal.py
+++ b/miru/modal.py
@@ -246,7 +246,7 @@ class Modal(ItemHandler[hikari.impl.ModalActionRowBuilder]):
 
     async def _handle_callback(self, context: ModalContext) -> None:
         """
-        Handle the callback of the modal. Seperate task in case the modal is stopped in the callback.
+        Handle the callback of the modal. Separate task in case the modal is stopped in the callback.
         """
         try:
             await self.callback(context)

--- a/miru/view.py
+++ b/miru/view.py
@@ -284,7 +284,7 @@ class View(ItemHandler[hikari.impl.MessageActionRowBuilder]):
 
     async def _handle_callback(self, item: ViewItem, context: ViewContext) -> None:
         """
-        Handle the callback of a view item. Seperate task in case the view is stopped in the callback.
+        Handle the callback of a view item. Separate task in case the view is stopped in the callback.
         """
         try:
             if self._message_id == context.message.id:


### PR DESCRIPTION
This PR adds miru.ext.nav.items.Page, which can be passed to NavigatorView to create more complex navigator pages