### PR TITLE
Update navigator.py to stop the ephemeral flag being set by default

### DIFF
--- a/miru/ext/nav/navigator.py
+++ b/miru/ext/nav/navigator.py
@@ -181,7 +181,6 @@ class NavigatorView(View):
             user_mentions=False,
             role_mentions=False,
             components=self,
-            flags=hikari.MessageFlag.EPHEMERAL,
         )
         if self.ephemeral:
             d["flags"] = hikari.MessageFlag.EPHEMERAL


### PR DESCRIPTION
Self explanatory, a flag was accidentally set on the navigator so it would always be sent as ephemeral. Tested and it works with both ephemeral and non-ephemeral messages now.