### PR TITLE
Fix menu.update_screen() not showing item addition/removal

### DIFF
--- a/miru/ext/menu/screen.py
+++ b/miru/ext/menu/screen.py
@@ -165,6 +165,7 @@ class Screen(abc.ABC):
 
         self._children.append(item)
         item._screen = self
+        self.menu.add_item(item)
 
         return self
 
@@ -187,6 +188,7 @@ class Screen(abc.ABC):
         except ValueError:
             pass
 
+        self.menu.remove_item(item)
         return self
 
     def clear_items(self) -> te.Self:
@@ -199,6 +201,7 @@ class Screen(abc.ABC):
         """
         for item in self.children:
             item._screen = None
+            self.menu.remove_item(item)
 
         self._children.clear()
         return self


### PR DESCRIPTION
Expected behavior is that Screens should allow their dynamic functions to be seen immediately in a menu.update_screen(). If I add a button to a screen after it is initially rendered, I expect the button to show up when the menu is refreshed. This is not the case because the menu only grabs the view's children on the initial screen load. This is just following the existing pattern to allow dynamic updates to propagate without a full reload.