### PR TITLE
Implement multiple starting screens in Menu().build_response_async()

### DIFF
--- a/miru/ext/menu/menu.py
+++ b/miru/ext/menu/menu.py
@@ -168,7 +168,7 @@ class Menu(miru.View):
         await self.update_message()
 
     async def build_response_async(
-        self, client: miru.Client, starting_screen: Screen, *, ephemeral: bool = False
+        self, client: miru.Client, starting_screen: Screen, *starting_screens: Screen, ephemeral: bool = False
     ) -> miru.MessageBuilder:
         """Create a REST response builder out of this Menu.
 
@@ -181,15 +181,19 @@ class Menu(miru.View):
         client : Client
             The client instance to use to build the response
         starting_screen : Screen
-            The screen to start the menu with.
+            The screen to start the menu with
+        *starting_screens : Screen
+            If provided, any extra starting screens after `starting_screen` (further in line - lower in the stack).
         ephemeral : bool
             Determines if the navigator will be sent ephemerally or not.
         """
         if self._client is not None:
             raise RuntimeError("Navigator is already bound to a client.")
 
+        starting_stack = (starting_screen, *starting_screens)
+
         self._ephemeral = ephemeral
-        self._stack.append(starting_screen)
+        self._stack.extend(starting_stack[::-1])
         await self._load_screen(starting_screen)
 
         builder = miru.MessageBuilder(

--- a/miru/ext/menu/menu.py
+++ b/miru/ext/menu/menu.py
@@ -183,7 +183,7 @@ class Menu(miru.View):
         starting_screen : Screen
             The screen to start the menu with.
         *starting_screens : Screen
-            If provided, any extra starting screens after `starting_screen` (further in line - lower in the stack).
+            If provided, any extra starting screens after `starting_screen` (further in line = higher in the stack).
         ephemeral : bool
             Determines if the navigator will be sent ephemerally or not.
         """
@@ -193,8 +193,8 @@ class Menu(miru.View):
         starting_stack = (starting_screen, *starting_screens)
 
         self._ephemeral = ephemeral
-        self._stack.extend(starting_stack[::-1])
-        await self._load_screen(starting_screen)
+        self._stack.extend(starting_stack)
+        await self._load_screen(starting_stack[-1])
 
         builder = miru.MessageBuilder(
             hikari.ResponseType.MESSAGE_CREATE, components=self, flags=self._flags, **self._payload

--- a/miru/ext/menu/menu.py
+++ b/miru/ext/menu/menu.py
@@ -181,7 +181,7 @@ class Menu(miru.View):
         client : Client
             The client instance to use to build the response
         starting_screen : Screen
-            The screen to start the menu with.
+The screen to start the menu with. If multiple screens are passed, this screen will be at the bottom of the stack.
         *starting_screens : Screen
             If provided, any extra starting screens after `starting_screen` (further in line = higher in the stack).
         ephemeral : bool

--- a/miru/ext/menu/menu.py
+++ b/miru/ext/menu/menu.py
@@ -181,7 +181,7 @@ class Menu(miru.View):
         client : Client
             The client instance to use to build the response
         starting_screen : Screen
-The screen to start the menu with. If multiple screens are passed, this screen will be at the bottom of the stack.
+            The screen to start the menu with. If multiple screens are passed, this screen will be at the bottom of the stack.
         *starting_screens : Screen
             If provided, any extra starting screens after `starting_screen` (further in line = higher in the stack).
         ephemeral : bool

--- a/miru/ext/menu/menu.py
+++ b/miru/ext/menu/menu.py
@@ -181,7 +181,7 @@ class Menu(miru.View):
         client : Client
             The client instance to use to build the response
         starting_screen : Screen
-            The screen to start the menu with
+            The screen to start the menu with.
         *starting_screens : Screen
             If provided, any extra starting screens after `starting_screen` (further in line - lower in the stack).
         ephemeral : bool


### PR DESCRIPTION
(as discussed on discord so not opening an issue)

> and this change is backwards compatible since the current signature of that function is: `(..., starting_screen: Screen, *, ...)` (see the `*`)

After i started implementing, i realised it's actually `/,` which would've allowed for backwards compatibility here (facepalm)
So i implemented it slightly differently to keep the backwards compatibility, now the passed screen stack is: further elements in the tuple = lower in stack, and i kept the current argument name instead of replacing it so the keyword argument still works:
```py
async def build_response_async(
    self, client: miru.Client, starting_screen: Screen, *starting_screens: Screen, ephemeral: bool = False
) -> miru.MessageBuilder:


```
If any modifications are needed, let me know!
[Example app](https://github.com/user-attachments/files/21000175/example.txt) (modified `/examples/menu.py`)