### PR TITLE
Make `View` & `Modal`'s default impl of `on_error()` use `logging.error()` instead of `print(file=sys.stderr)`

### DIFF
--- a/miru/modal.py
+++ b/miru/modal.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import logging
 import os
 import sys
 import traceback
@@ -25,6 +26,7 @@ if t.TYPE_CHECKING:
 
 __all__ = ("Modal",)
 
+logger = logging.getLogger(__name__)
 
 class Modal(
     ItemHandler[
@@ -182,7 +184,7 @@ class Modal(
         context : Optional[Context]
             The context associated with this exception, if any.
         """
-        print(f"Ignoring exception in modal {self}:", file=sys.stderr)
+        logger.error("Ignoring exception in modal %s:", self, exc_info=error)
 
         traceback.print_exception(type(error), error, error.__traceback__, file=sys.stderr)
 

--- a/miru/modal.py
+++ b/miru/modal.py
@@ -28,6 +28,7 @@ __all__ = ("Modal",)
 
 logger = logging.getLogger(__name__)
 
+
 class Modal(
     ItemHandler[
         hikari.impl.ModalActionRowBuilder, ModalResponseBuildersT, ModalContext, hikari.ModalInteraction, ModalItem

--- a/miru/view.py
+++ b/miru/view.py
@@ -287,11 +287,9 @@ class View(
             The context associated with this exception, if any.
         """
         if item:
-            print(f"Ignoring exception in view {self} for item {item}:", file=sys.stderr)
+            logger.error("Ignoring exception in view %s for item %s:", self, item, exc_info=error)
         else:
-            print(f"Ignoring exception in view {self}:", file=sys.stderr)
-
-        traceback.print_exception(type(error), error, error.__traceback__, file=sys.stderr)
+            logger.error("Ignoring exception in view %s:", self, exc_info=error)
 
     async def _handle_callback(self, item: InteractiveViewItem, context: ViewContext) -> None:
         """Handle the callback of a view item. Separate task in case the view is stopped in the callback."""

--- a/miru/view.py
+++ b/miru/view.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import asyncio
 import copy
 import logging
-import sys
-import traceback
 import typing as t
 
 import hikari


### PR DESCRIPTION
This change allows for logging the "Ignoring exception in view" errors + compatibility with logging customizers (e.g. `rich.logging` or a manual impl of a handler), which formats tracebacks in a different way than python's default. Before this change the way to do it would be to subclass `miru.View` and import & *remember* to use that subclass across the project. I think this change makes for a nicer default.

Example (upper half some other error, lower half miru's error):
<img width="1913" height="518" alt="image" src="https://github.com/user-attachments/assets/d041380e-d75f-42f9-92d2-4f5f9cb9c7a3" />

With this change:
<img width="1911" height="554" alt="image" src="https://github.com/user-attachments/assets/2eccd762-762c-4131-a945-5cb184a1039b" />
